### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Visionary-Code-Works/visionary-code-works.github.io/security/code-scanning/4](https://github.com/Visionary-Code-Works/visionary-code-works.github.io/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block defining the minimal GitHub token scopes required. For a Jekyll build job that also deploys to GitHub Pages via `peaceiris/actions-gh-pages@v3`, the job needs read access to repository contents to build and write access to `gh-pages` (or the target branch) to push the generated site. A common minimal configuration is `contents: read` for pure CI jobs, and `contents: write` when deployment pushes commits.

The most targeted fix, without changing existing functionality, is to add a `permissions` block under the `build` job (indented under `build:` at the same level as `runs-on:`). Since this job both builds and deploys, and deployment uses `github_token`, we should grant `contents: write` there. If you later split deployment into a separate job, you could then narrow `build` back to `contents: read`, but with the current single job structure we cannot reduce write permissions without breaking deployment.

Concretely:
- Edit `.github/workflows/jekyll.yml`.
- Under `jobs:`, inside `build:`, add:

  ```yaml
    permissions:
      contents: write
  ```

- Place it above or below `runs-on: ubuntu-latest` with correct indentation (two spaces under `build:`).

No additional imports or external dependencies are required; this is purely a workflow YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
