### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,8 @@
 name: Auto Update Changelog
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Visionary-Code-Works/visionary-code-works.github.io/security/code-scanning/3](https://github.com/Visionary-Code-Works/visionary-code-works.github.io/security/code-scanning/3)

In general, fix this by adding an explicit `permissions` block either at the workflow root (applies to all jobs) or within the specific job, granting only the scopes needed. For this workflow, the job needs to push commits back to the repository, so it requires `contents: write`; it does not obviously require other scopes like `issues`, `pull-requests`, etc., so those should be omitted.

The best minimal fix without changing behavior is to define `permissions` at the root level (just under `name:`) so it applies to `update-changelog`. Add:

```yaml
permissions:
  contents: write
```

between the `name:` line and the `on:` block in `.github/workflows/changelog.yml`. No other changes, imports, or additional configuration are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
